### PR TITLE
Adapt Pages build to custom domains

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,10 +29,13 @@ jobs:
           node-version: 22
           cache: pnpm
 
-      - uses: actions/configure-pages@v5
+      - id: pages
+        uses: actions/configure-pages@v5
 
       - run: pnpm install --frozen-lockfile
       - run: pnpm build
+        env:
+          BASE_PATH: ${{ steps.pages.outputs.base_path }}/
 
       - uses: actions/upload-pages-artifact@v4
         with:


### PR DESCRIPTION
## What changed

- expose the `actions/configure-pages` step output
- pass its `base_path` to the Vite build as `BASE_PATH`

## Why

The Pages site currently uses the project path `/Gasyori100knockJS/`, but the custom domain serves it from `/`. Reading the configured Pages base path keeps the same workflow valid before and after the domain switch.

## Validation

- `pnpm check`
- `BASE_PATH=/ pnpm build`
- `BASE_PATH=/Gasyori100knockJS/ pnpm build`
